### PR TITLE
[SELS_BUGFIX] Profile View for Following and Followed Users

### DIFF
--- a/backend/core/urls.py
+++ b/backend/core/urls.py
@@ -8,7 +8,7 @@ from dj_rest_auth.views import PasswordResetConfirmView
 from elearning.views import LessonAnsweringPostView
 
 urlpatterns = [
-    path("admin", admin.site.urls),
+    path("admin/", admin.site.urls),
     path("api/v1/", include("api.urls")),
     path(
         "dj-rest-auth/",

--- a/backend/eprofile/models.py
+++ b/backend/eprofile/models.py
@@ -61,18 +61,18 @@ class UserFollowing(models.Model):
         ]
 
     def save(self, *args, **kwargs):
+        super().save(*args, **kwargs)
         self.follower.following_count += 1
         self.follower.save()
         self.following.follower_count += 1
         self.following.save()
-        super().save(*args, **kwargs)
 
     def delete(self, *args, **kwargs):
+        super().delete(*args, **kwargs)
         self.follower.following_count -= 1
         self.follower.save()
         self.following.follower_count -= 1
         self.following.save()
-        super().delete(*args, **kwargs)
 
 
 @receiver(post_save, sender=User)

--- a/frontend/src/components/elements/FollowButton.js
+++ b/frontend/src/components/elements/FollowButton.js
@@ -9,12 +9,12 @@ import UserService from '../../services/user.service'
 const Toast = Swal.mixin({
   toast: true,
   position: 'top-right',
-  iconColor: 'white',
+  iconColor: 'black',
   customClass: {
     popup: 'colored-toast',
   },
   showConfirmButton: false,
-  timer: 300,
+  timer: 900,
   timerProgressBar: true,
 })
 
@@ -36,6 +36,35 @@ const FollowButton = (props) => {
           navigate(0)
         })
       }
+      if (response.status === 400) {
+        Toast.fire({
+          icon: 'error',
+          title: 'Already followed!',
+          timer: 2000,
+        })
+      }
+
+      if (response.status === 401) {
+        Toast.fire({
+          icon: 'error',
+          title: 'Unauthorized!',
+          timer: 2000,
+        })
+      }
+
+      if (response.status === 500) {
+        Toast.fire({
+          icon: 'error',
+          title: 'Server Error! Please refresh the site',
+          customClass: {
+            popup: 'colored-toast',
+          },
+          timer: 2000,
+        }).then(() => {
+          navigate(0)
+        })
+      }
+
       return response
     } else {
       const response = await UserService.deleteUserFollowing(
@@ -51,6 +80,16 @@ const FollowButton = (props) => {
           navigate(0)
         })
       }
+
+      if (response.status === 500) {
+        Toast.fire({
+          icon: 'error',
+          title: 'Server Error! Please refresh the site',
+        }).then(() => {
+          navigate(0)
+        })
+      }
+
       return response
     }
   }, [props])

--- a/frontend/src/index.js
+++ b/frontend/src/index.js
@@ -13,7 +13,7 @@ const root = createRoot(container)
 root.render(
   <CookiesProvider>
     <Provider store={store}>
-      <BrowserRouter>
+      <BrowserRouter forceRefresh={true}>
         <App />
       </BrowserRouter>
     </Provider>


### PR DESCRIPTION
**[Asana Link]**
https://app.asana.com/0/1202968674806069/1202968800626990/f
https://app.asana.com/0/1202968674806069/1202968800626992/f

**[Preconditions]**
Suppose you are already following a user, when you visit his page, you can see the list of his followers: `http://127.0.0.1:3000/profile/2` (See Screenshot 1)

Clicking the link going to your profile and then clicking the link going to his profile continuously (although this might not happen to the usual users), when you try to unfollow the user, it throws an error (only shown in the console). To handle this bug, the following changes are made:

- When the error is encountered, display a toast saying that unfollowing the user is not successful, and ask the user to refresh the page and try again.
- Whether the user refreshes the page or not, once the toast dismisses the page refreshes. The user can try unfollowing the user again.

**[Screenshots]**
**Screenshot 1**
![image](https://user-images.githubusercontent.com/109291819/193484252-05b7cf06-81f8-4bf6-a7e6-bb40498b64f8.png)

**Screenshot 2**
When the error is encountered. The toast automatically dismisses given a set time limit and automatically refreshes the page so the user can try unfollowing the user again.
![image](https://user-images.githubusercontent.com/109291819/193484327-ab6a65ee-d0cd-4d09-a665-48fc6f5f6597.png)
